### PR TITLE
Changes for better MRS system diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ find_package(catkin REQUIRED COMPONENTS
   ${CATKIN_DEPENDENCIES}
   )
 
+# messages for ROBOT_DIAGNOSTICS
+add_message_files(DIRECTORY msg/robot_diagnostics FILES
+  UavDiagnostics.msg
+  )
+
 # messages for MPC_TRACKER
 add_message_files(DIRECTORY msg/mpc_tracker FILES
 

--- a/msg/robot_diagnostics/UavDiagnostics.msg
+++ b/msg/robot_diagnostics/UavDiagnostics.msg
@@ -1,0 +1,3 @@
+time stamp
+
+string state

--- a/msg/uav_managers/TrackerStatus.msg
+++ b/msg/uav_managers/TrackerStatus.msg
@@ -1,6 +1,16 @@
 bool active
 bool callbacks_enabled
 
+# current tracker state
+uint8 state
+uint8 STATE_INVALID     = 0
+uint8 STATE_IDLE        = 1
+uint8 STATE_TAKEOFF     = 2
+uint8 STATE_HOVER       = 3
+uint8 STATE_REFERENCE   = 4
+uint8 STATE_TRAJECTORY  = 5
+uint8 STATE_LAND        = 6
+
 # is true whenever the tracker is doing something
 # in other words, not idling
 bool have_goal


### PR DESCRIPTION
Added a placeholder diagnostics message, added the `state` field to the `TrackerStatus` message. Should be merged together with the respective changes in the `mrs_uav_trackers` repo.