### PR TITLE
[ROS2] Fix: Proper message and services definitions installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,4 +23,17 @@ rosidl_generate_interfaces(${PROJECT_NAME}
     DEPENDENCIES builtin_interfaces geometry_msgs std_msgs sensor_msgs std_srvs
   )
 
+# Manually install .msg and .srv files to the share folder.
+# This ensures 'ros2 interface show' finds the original files
+# instead of falling back to the .idl files which contain unparseable comments.
+install(
+  FILES ${msg_files}
+  DESTINATION "share/${PROJECT_NAME}/msg"
+)
+
+install(
+  FILES ${srv_files}
+  DESTINATION "share/${PROJECT_NAME}/srv"
+)
+
 ament_package()


### PR DESCRIPTION
## Fix: Proper message and services definitions installation

### Problem
The command `ros2 interface show` crashes when messages are stored in nested subfolders because it cannot locate the `.msg` files, forcing a fallback to a problematic `.idl` parser. The message files are installed using the CMake macro `rosidl_generate_interfaces`, but they are not found in the specified subfolders as intended.

Try for example:
`ros2 interface show mrs_msgs/msg/UavStatusShort`

### Solution
Explicitly install `.msg` and `.srv` files into a flat `share/${PROJECT_NAME}/msg` and `srv` directory. This ensures the CLI tools find the original definitions and avoid the IDL parsing crash.

### Verification
`ros2 interface show mrs_msgs/msg/UavStatusShort` should now work without a traceback.