### PR TITLE
[ROS2] feat: add validation for missing and duplicate interface files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,35 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+function(mrs_validate_interfaces FILE_LIST EXTENSION)
+  # 1. Check for physical files that were forgotten in the list
+  file(GLOB_RECURSE physical_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.${EXTENSION}")
+
+  foreach(p_file ${physical_files})
+    if(IS_SYMLINK "${CMAKE_CURRENT_SOURCE_DIR}/${p_file}")
+      continue()
+    endif()
+
+    if(NOT "${p_file}" IN_LIST ${FILE_LIST})
+      message(WARNING "MISSING ${EXTENSION}: '${p_file}' exists in the folder but is NOT in your ${FILE_LIST}!")
+    endif()
+  endforeach()
+
+  # 2. Check for naming collisions (Duplicate filenames in different subfolders)
+  set(seen_names "")
+  foreach(file_path ${${FILE_LIST}})
+    get_filename_component(file_name ${file_path} NAME)
+
+    if("${file_name}" IN_LIST seen_names)
+      message(FATAL_ERROR
+        "NAMING COLLISION: Multiple ${EXTENSION} files named '${file_name}' found in ${PROJECT_NAME}. "
+        "ROS 2 requires unique filenames to flatten the install directory correctly."
+        )
+    endif()
+    list(APPEND seen_names ${file_name})
+  endforeach()
+endfunction()
+
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
@@ -16,6 +45,9 @@ find_package(geometry_msgs REQUIRED)
 # these files are auto-generated using the copy script
 include(msg_list.txt)
 include(srv_list.txt)
+
+mrs_validate_interfaces(msg_files "msg")
+mrs_validate_interfaces(srv_files "srv")
 
 rosidl_generate_interfaces(${PROJECT_NAME}
     ${msg_files}


### PR DESCRIPTION
# Overview
This PR adds a safety layer to the `mrs_msgs` build process to prevent common configuration errors.

### Validation Features
- **Forgotten Files:** The build will now **WARNING** you if a `.msg` or `.srv` file exists in the source folder but was forgotten in the `CMakeLists.txt` variables.
- **Duplicate Names:** It now triggers a **FATAL_ERROR** if two files have the same name (e.g., `folder1/Status.msg` and `folder2/Status.msg`), preventing silent overwrites.
- **Symlink Awareness:** Automatically ignores symlinks to focus only on real source files.

### Testing
The current `ros2` branch has a problem that `srv/PrismSrv.srv` was not added to `srv_list.txt`. Automatic CI build will find this and mention it.

Note: adding `srv/PrismSrv.srv` is part of https://github.com/ctu-mrs/mrs_msgs/pull/20. So when this PR is merged, we can rebase and merge the https://github.com/ctu-mrs/mrs_msgs/pull/20. 