### PR TITLE
Feat/rc rssi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(msg_files
   msg/hw_api/HwApiControlGroupCmd.msg
   msg/hw_api/HwApiPositionCmd.msg
   msg/hw_api/HwApiRcChannels.msg
+  msg/hw_api/HwApiRcRssi.msg
   msg/hw_api/HwApiStatus.msg
   msg/hw_api/HwApiVelocityHdgCmd.msg
   msg/hw_api/HwApiVelocityHdgRateCmd.msg

--- a/msg/hw_api/HwApiCapabilities.msg
+++ b/msg/hw_api/HwApiCapabilities.msg
@@ -21,6 +21,7 @@ bool produces_distance_sensor
 bool produces_altitude
 bool produces_magnetometer_heading
 bool produces_rc_channels
+bool produces_rc_rssi
 bool produces_battery_state
 bool produces_position
 bool produces_orientation

--- a/msg/hw_api/HwApiRcRssi.msg
+++ b/msg/hw_api/HwApiRcRssi.msg
@@ -1,0 +1,4 @@
+builtin_interfaces/Time stamp
+
+# Received signal strength indicator in % 
+uint8 rssi


### PR DESCRIPTION
## Summary
- **What changed**:
    - Adding msg for `HwApiRCRssi` message, and extended `HWApiCapabilities` message.
- **Why**:
    - Currently, `HwApi` only shares the **RC Channels**,  and not using the  **RC Received Signal Strength Indicator (RSSI)**  that PX4 already shares in the `rc` [message](https://github.com/mavlink/mavros/blob/master/mavros_msgs/msg/RCIn.msg#L4)
- **Notes for reviewers**:
    - Added new message to keep backwards compatibility without modifying `RC Channels` message
## Impact
- **Affected areas**: `HwApiCababilities` message
- **Breaking changes**: Yes, given possible ABI mismatch with the new HwApiCababilities field `produces_rssi`

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [] Tests updated if needed
    * [x] Tested in simulation
    * [x] Tested on real HW