### PR TITLE
feat: set weekly check for Github actions dependecies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Optional: labels to apply to the PRs
+    labels:
+      - "dependencies"
+      - "github_actions"


### PR DESCRIPTION
This pull request introduces a configuration file for Dependabot to automate dependency updates for GitHub Actions workflows. Dependabot will now check for updates weekly and label related pull requests appropriately.
